### PR TITLE
Fix wasm specific things

### DIFF
--- a/Sources/CRuntime/include/CRuntime.h
+++ b/Sources/CRuntime/include/CRuntime.h
@@ -3,13 +3,6 @@
 
 #include <stddef.h>
 
-__attribute__((swiftcall))
-const void * _Nullable swift_getTypeByMangledNameInContext(
-                        const char * _Nullable typeNameStart,
-                        size_t typeNameLength,
-                        const void * _Nullable context,
-                        const void * _Nullable const * _Nullable genericArgs);
-
 const void * _Nullable swift_allocObject(
                     void const* _Nullable type,
                     size_t requiredSize,

--- a/Sources/Runtime/Pointers/RelativePointer.swift
+++ b/Sources/Runtime/Pointers/RelativePointer.swift
@@ -28,12 +28,16 @@ struct RelativePointer<Offset: FixedWidthInteger, Pointee> {
     }
     
     mutating func advanced() -> UnsafeMutablePointer<Pointee> {
+        #if arch(wasm32)
+        return unsafeBitCast(offset, to: UnsafeMutablePointer<Pointee>.self)
+        #else
         let offset = self.offset
         return withUnsafePointer(to: &self) { p in
             return p.raw.advanced(by: numericCast(offset))
                 .assumingMemoryBound(to: Pointee.self)
                 .mutable
         }
+        #endif
     }
 }
 


### PR DESCRIPTION
- https://github.com/MaxDesiatov/Runtime/pull/1/commits/ee86842931ef7057b7b58c0ce7858f6a60538abc Call `swift_getTypeByMangledNameInContext` using swiftcc

C header side annotation _ _ attribute _ _((swiftcall)) doesn't affect to
call site in Swift code. So swift_getTypeByMangledNameInContext was
called using C convention.

Therefore we need to declare the function in Swift.

- https://github.com/MaxDesiatov/Runtime/pull/1/commits/fafd9e2cdf0c9fc11cdcad1c24540ad1a7c03e4d Handle absolute pointer