### PR TITLE
Call swift_getTypeByMangledNameInContext inside CRuntime

### DIFF
--- a/Sources/CRuntime/CRuntime.c
+++ b/Sources/CRuntime/CRuntime.c
@@ -1,0 +1,17 @@
+#include <CRuntime.h>
+
+__attribute__((swiftcall))
+extern const void * _Nullable swift_getTypeByMangledNameInContext(
+                        const char * _Nullable typeNameStart,
+                        size_t typeNameLength,
+                        const void * _Nullable context,
+                        const void * _Nullable const * _Nullable genericArgs);
+
+const void * _Nullable cruntime_getTypeByMangledNameInContext(
+                        const char * _Nullable typeNameStart,
+                        size_t typeNameLength,
+                        const void * _Nullable context,
+                        const void * _Nullable const * _Nullable genericArgs) {
+  return swift_getTypeByMangledNameInContext(typeNameStart, typeNameLength, context, genericArgs);
+}
+

--- a/Sources/CRuntime/include/CRuntime.h
+++ b/Sources/CRuntime/include/CRuntime.h
@@ -3,6 +3,12 @@
 
 #include <stddef.h>
 
+const void * _Nullable cruntime_getTypeByMangledNameInContext(
+                        const char * _Nullable typeNameStart,
+                        size_t typeNameLength,
+                        const void * _Nullable context,
+                        const void * _Nullable const * _Nullable genericArgs);
+
 const void * _Nullable swift_allocObject(
                     void const* _Nullable type,
                     size_t requiredSize,

--- a/Sources/Runtime/Layouts/FieldDescriptor.swift
+++ b/Sources/Runtime/Layouts/FieldDescriptor.swift
@@ -24,14 +24,6 @@
 import CRuntime
 #endif
 
-@_silgen_name("swift_getTypeByMangledNameInContext")
-func _getTypeByMangledNameInContext(
-  _ name: UnsafePointer<UInt8>,
-  _ nameLength: UInt,
-  _ genericContext: UnsafeRawPointer?,
-  _ genericArguments: UnsafeRawPointer?)
-  -> Any.Type?
-
 /// https://github.com/apple/swift/blob/f2c42509628bed66bf5b8ee02fae778a2ba747a1/include/swift/Reflection/Records.h#L160
 struct FieldDescriptor {
     
@@ -50,7 +42,7 @@ struct FieldDescriptor {
 struct FieldRecord {
     
     var fieldRecordFlags: Int32
-    var _mangledTypeName: RelativePointer<Int32, UInt8>
+    var _mangledTypeName: RelativePointer<Int32, Int8>
     var _fieldName: RelativePointer<Int32, UInt8>
     
     var isVar: Bool {
@@ -68,15 +60,16 @@ struct FieldRecord {
     mutating func type(genericContext: UnsafeRawPointer?,
                        genericArguments: UnsafeRawPointer?) -> Any.Type {
         let typeName = _mangledTypeName.advanced()
-        return _getTypeByMangledNameInContext(
+        let metadataPtr = cruntime_getTypeByMangledNameInContext(
             typeName,
             getSymbolicMangledNameLength(typeName),
             genericContext,
             genericArguments?.assumingMemoryBound(to: Optional<UnsafeRawPointer>.self)
         )!
+        return unsafeBitCast(metadataPtr, to: Any.Type.self)
     }
     
-    func getSymbolicMangledNameLength(_ base: UnsafeRawPointer) -> UInt {
+    func getSymbolicMangledNameLength(_ base: UnsafeRawPointer) -> Int {
         var end = base
         while let current = Optional(end.load(as: UInt8.self)), current != 0 {
             end += 1
@@ -87,7 +80,7 @@ struct FieldRecord {
             }
         }
         
-        return UInt(end - base)
+        return Int(end - base)
     }
 }
 


### PR DESCRIPTION
This would fix @wickwirew pointed issue https://github.com/wickwirew/Runtime/pull/71/files#r419838634

But not work well yet due to the clang version mismatch. clang embedded in wasm-DEVELOPMENT-SNAPSHOT-2020-04-28-a is pointing [b451d1a61](https://github.com/swiftwasm/llvm-project/tree/b451d1a610a98a62cdbf5e3e94d77d446b18a5e0) which doesn't include [my swiftcc support patch](https://reviews.llvm.org/D76049). 

I think after https://github.com/swiftwasm/swift/pull/719 merged, it will work well.